### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/ct.el
+++ b/ct.el
@@ -7,7 +7,7 @@
 ;; Author: neeasade
 ;; Keywords: convenience color theming rgb hsv hsl cie-lab background
 ;; URL: https://github.com/neeasade/ct.el
-;; Package-Requires: ((emacs "26.1") (dash "2.17.0") (dash-functional "2.17.0") (hsluv "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.18.0") (hsluv "1.0.0"))
 
 ;;; Commentary:
 ;; neeasade's color tools for Emacs.
@@ -28,7 +28,6 @@
 
 (require 'hsluv)
 (require 'dash)
-(require 'dash-functional)
 
 ;; customization:
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218